### PR TITLE
Remove unused toggle muis event

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -521,18 +521,6 @@ RegisterNetEvent('qb-taxi:client:enableMeter', function()
     end
 end)
 
-RegisterNetEvent('qb-taxi:client:toggleMuis', function()
-    Wait(400)
-    if meterIsOpen then
-        if not mouseActive then
-            SetNuiFocus(true, true)
-            mouseActive = true
-        end
-    else
-        QBCore.Functions.Notify(Lang:t('error.no_meter_sight'), 'error')
-    end
-end)
-
 -- NUI Callbacks
 
 RegisterNUICallback('enableMeter', function(data, cb)

--- a/locales/ar.lua
+++ b/locales/ar.lua
@@ -5,7 +5,6 @@ local Translations = {
         ["missing_meter"] = "هذه السيارة لا تحتوي على عداد سيارات الأجرة",
         ["no_vehicle"] = "أنت لست في سيارة",
         ["not_active_meter"] = "عداد سيارة الأجرة غير نشط",
-        ["no_meter_sight"] = "لا يوجد عداد سيارات الأجرة في الأفق",
         ["no_mission_active"] = "You dont have any mission to cancel"
     },
     success = {

--- a/locales/da.lua
+++ b/locales/da.lua
@@ -5,7 +5,6 @@ local Translations = {
         ["missing_meter"] = "Dette køretøj har intet taxameter",
         ["no_vehicle"] = "Du er ikke i et køretøj",
         ["not_active_meter"] = "Taxameteret er ikke aktivt",
-        ["no_meter_sight"] = "Intet taxameter at se",
         ["no_mission_active"] = "You dont have any mission to cancel"
     },
     success = {

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -5,7 +5,6 @@ local Translations = {
         ["missing_meter"] = "Dieses Fahrzeug hat keine Taxameter",
         ["no_vehicle"] = "Sie sind nicht in einem Fahrzeug",
         ["not_active_meter"] = "Das Taxameter ist nicht aktiv",
-        ["no_meter_sight"] = "Kein Taxameter in Sicht",
         ["no_mission_active"] = "You dont have any mission to cancel"
     },
     success = {

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -5,7 +5,6 @@ local Translations = {
         ["missing_meter"] = "This Vehicle Has No Taxi Meter",
         ["no_vehicle"] = "You're not in a vehicle",
         ["not_active_meter"] = "The Taxi Meter Is Not Active",
-        ["no_meter_sight"] = "No Taxi Meter In Sight",
         ["no_mission_active"] = "You dont have any mission to cancel"
     },
     success = {

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -5,7 +5,6 @@ local Translations = {
         ["missing_meter"] = "Este vehículo no tiene taxímetro",
         ["no_vehicle"] = "No estás en un vehículo",
         ["not_active_meter"] = "El taxímetro no está activo",
-        ["no_meter_sight"] = "No hay taxímetro visible",
         ["no_mission_active"] = "You dont have any mission to cancel"
     },
     success = {

--- a/locales/fa.lua
+++ b/locales/fa.lua
@@ -5,7 +5,6 @@ local Translations = {
         ["missing_meter"] = "Dar In Vasile Nagliye Taxi Meter Mojud Nist",
         ["no_vehicle"] = "Shoma Dar Vasile Nagliye Nist",
         ["not_active_meter"] = "Taxi Meter Faal Nist",
-        ["no_meter_sight"] = "Taxi Meter Dar Maraze Did Nist",
         ["no_mission_active"] = "You dont have any mission to cancel"
     },
     success = {

--- a/locales/fi.lua
+++ b/locales/fi.lua
@@ -5,7 +5,6 @@ local Translations = {
         ["missing_meter"] = "Ajoneuvossa ei ole taksimittaria",
         ["no_vehicle"] = "Et ole ajoneuvossa!",
         ["not_active_meter"] = "Taksimittari ei ole aktiivinen",
-        ["no_meter_sight"] = "Ei taksimittaria nähtävissä",
         ["no_mission_active"] = "You dont have any mission to cancel"
     },
     success = {

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -5,7 +5,6 @@ local Translations = {
         ["missing_meter"] = "Ce véhicule n'a pas de taximètre",
         ["no_vehicle"] = "Vous n\'êtes pas dans un véhicule",
         ["not_active_meter"] = "Le taximètre n\'est pas activé",
-        ["no_meter_sight"] = "Pas de taximètre en vue",
         ["no_mission_active"] = "You dont have any mission to cancel"
     },
     success = {

--- a/locales/it.lua
+++ b/locales/it.lua
@@ -5,7 +5,6 @@ local Translations = {
         ["missing_meter"] = "Questo veicolo non ha un tassametro",
         ["no_vehicle"] = "Non sei in un veicolo",
         ["not_active_meter"] = "Il tassametro non è acceso",
-        ["no_meter_sight"] = "Nessun tassametro visibile",
         ["no_mission_active"] = "Non hai tratte da annullare"
     },
     success = {

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -5,7 +5,6 @@ local Translations = {
         ["missing_meter"] = "Dit voertuig heeft geen taximeter",
         ["no_vehicle"] = "Je zit niet in een voertuig",
         ["not_active_meter"] = "De taximeter is niet actief",
-        ["no_meter_sight"] = "Geen taximeter in zicht",
         ["no_mission_active"] = "You dont have any mission to cancel"
     },
     success = {

--- a/locales/pt-br.lua
+++ b/locales/pt-br.lua
@@ -5,7 +5,6 @@ local Translations = {
         ["missing_meter"] = "Este veículo não possui taxímetro",
         ["no_vehicle"] = "Você não está em um veículo",
         ["not_active_meter"] = "O taxímetro não está ativo",
-        ["no_meter_sight"] = "Nenhum taxímetro à vista",
     },
     success = {},
     info = {

--- a/locales/pt.lua
+++ b/locales/pt.lua
@@ -5,7 +5,6 @@ local Translations = {
         ["missing_meter"] = "Este veículo não possui um taxímetro",
         ["no_vehicle"] = "Não estás num veículo",
         ["not_active_meter"] = "O taxímetro não se encontra activo",
-        ["no_meter_sight"] = "Nenhum taxímetro à vista",
         ["no_mission_active"] = "You dont have any mission to cancel"
     },
     success = {

--- a/locales/sv.lua
+++ b/locales/sv.lua
@@ -5,7 +5,6 @@ local Translations = {
         ["missing_meter"] = "Det här fordonet har ingen taxameter",
         ["no_vehicle"] = "Du är inte i ett fordon",
         ["not_active_meter"] = "Taxametern är inte aktiv",
-        ["no_meter_sight"] = "Ingen Taxameter i sikte",
         ["no_mission_active"] = "You dont have any mission to cancel"
     },
     success = {

--- a/locales/th.lua
+++ b/locales/th.lua
@@ -5,7 +5,6 @@ local Translations = {
         ["missing_meter"] = "รถคันนี้ไม่มีมิเตอร์แท็กซี่",
         ["no_vehicle"] = "คุณไม่ได้อยู่ในยานพาหนะ",
         ["not_active_meter"] = "มิเตอร์แท็กซี่ไม่ทำงาน",
-        ["no_meter_sight"] = "ไม่มีมิเตอร์แท็กซี่ในระยะสายตา",
         ["no_mission_active"] = "You dont have any mission to cancel"
     },
     success = {

--- a/locales/tr.lua
+++ b/locales/tr.lua
@@ -5,7 +5,6 @@ local Translations = {
         ["missing_meter"] = "Bu Aracın Taksimetresi Yok",
         ["no_vehicle"] = "Bir araçta değilsin",
         ["not_active_meter"] = "Taksimetre Aktif Değil",
-        ["no_meter_sight"] = "Görünürde Taksimetre Yok",
         ["no_mission_active"] = "You dont have any mission to cancel"
     },
     success = {


### PR DESCRIPTION
**Describe Pull request**
Essentially there is an unused client side event lingering within our `main.lua` by the name of `qb-taxi:client:toggleMuis`.

I don't see any references to this event within any of `qb-` resources nor other projects https://github.com/search?q=qb-taxi%3Aclient%3AtoggleMuis+language%3ALua+&type=code&p=1

It seems like the goal of this event is to allow players to remove NUI focus which doesn't make sense for this script as the taxi meter doesn't have any interaction available, its essentially view only.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
Yes I have. Upon removing the event the script worked as it did prior.

- Does your code fit the style guidelines? [yes/no]
yes
- Does your PR fit the contribution guidelines? [yes/no]
yes