### PR TITLE
Fixed off duty table's translations

### DIFF
--- a/locales/ar.lua
+++ b/locales/ar.lua
@@ -21,7 +21,7 @@ local Translations = {
         ["blip_name"] = "ﻲﺴﻛﺎﺘﻟﺍ ﺰﻛﺮﻣ",
         ["taxi_label_1"] = "تاكسي",
         ["on_duty"] = "[E] - Go on duty",
-        ["on_duty"] = "[E] - Go off duty"
+        ["off_duty"] = "[E] - Go off duty"
     },
     menu = {
         ["taxi_menu_header"] = "سيارات التاكسي",

--- a/locales/da.lua
+++ b/locales/da.lua
@@ -21,7 +21,7 @@ local Translations = {
         ["blip_name"] = "Midtby taxa",
         ["taxi_label_1"] = "Standart taxa",
         ["on_duty"] = "[E] - Go on duty",
-        ["on_duty"] = "[E] - Go off duty"
+        ["off_duty"] = "[E] - Go off duty"
     },
     menu = {
         ["taxi_menu_header"] = "Taxa køretøjer",

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -23,7 +23,7 @@ local Translations = {
         ["no_spawn_point"] = "Unfähig, einen Ort zu finden, an den das Taxi gebracht werden kann",
         ["taxi_returned"] = "Taxi einparken",
         ["on_duty"] = "[E] - Go on duty",
-        ["on_duty"] = "[E] - Go off duty"
+        ["off_duty"] = "[E] - Go off duty"
     },
     menu = {
         ["taxi_menu_header"] = "Taxifahrzeuge",

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -23,7 +23,7 @@ local Translations = {
         ["no_spawn_point"] = "Unable to find a location to bring the cab",
         ["taxi_returned"] = "Cab Parked",
         ["on_duty"] = "[E] - Go on duty",
-        ["on_duty"] = "[E] - Go off duty"
+        ["off_duty"] = "[E] - Go off duty"
     },
     menu = {
         ["taxi_menu_header"] = "Taxi Vehicles",

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -23,7 +23,7 @@ local Translations = {
         ["no_spawn_point"] = "No es posible encontrar una ubicación para traer el taxi",
         ["taxi_returned"] = "Taxi estacionado",
         ["on_duty"] = "[E] - Go on duty",
-        ["on_duty"] = "[E] - Go off duty"
+        ["off_duty"] = "[E] - Go off duty"
     },
     menu = {
         ["taxi_menu_header"] = "Vehículos para taxi",

--- a/locales/fa.lua
+++ b/locales/fa.lua
@@ -21,7 +21,7 @@ local Translations = {
         ["blip_name"] = "Downtown Cab",
         ["taxi_label_1"] = "Taxi Mamuli",
         ["on_duty"] = "[E] - Go on duty",
-        ["on_duty"] = "[E] - Go off duty"
+        ["off_duty"] = "[E] - Go off duty"
     },
     menu = {
         ["taxi_menu_header"] = "List Mashin heye Taxi",

--- a/locales/fi.lua
+++ b/locales/fi.lua
@@ -21,7 +21,7 @@ local Translations = {
         ["blip_name"] = "Taksi",
         ["taxi_label_1"] = "Taksi",
         ["on_duty"] = "[E] - Go on duty",
-        ["on_duty"] = "[E] - Go off duty"
+        ["off_duty"] = "[E] - Go off duty"
     },
     menu = {
         ["taxi_menu_header"] = "Taksit",

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -23,7 +23,7 @@ local Translations = {
         ["no_spawn_point"] = "Impossible de trouver un emplacement pour amener le taxi",
         ["taxi_returned"] = "Taxi Garé",
         ["on_duty"] = "[E] - Go on duty",
-        ["on_duty"] = "[E] - Go off duty"
+        ["off_duty"] = "[E] - Go off duty"
     },
     menu = {
         ["taxi_menu_header"] = "Taxi",

--- a/locales/it.lua
+++ b/locales/it.lua
@@ -21,7 +21,7 @@ local Translations = {
         ["blip_name"] = "Taxi",
         ["taxi_label_1"] = "Taxi Base",
         ["on_duty"] = "[E] - Vai in servizio",
-        ["on_duty"] = "[E] - Vai fuori servizio"
+        ["off_duty"] = "[E] - Vai fuori servizio"
     },
     menu = {
         ["taxi_menu_header"] = "Veicoli Taxi",

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -21,7 +21,7 @@ local Translations = {
         ["blip_name"] = "Downtown Cab",
         ["taxi_label_1"] = "Standaard Cab",
         ["on_duty"] = "[E] - Go on duty",
-        ["on_duty"] = "[E] - Go off duty"
+        ["off_duty"] = "[E] - Go off duty"
         },
     menu = {
         ["taxi_menu_header"] = "Taxi Voertuigen",

--- a/locales/pt.lua
+++ b/locales/pt.lua
@@ -21,7 +21,7 @@ local Translations = {
         ["blip_name"] = "Taxis da Baixa",
         ["taxi_label_1"] = "Taxi",
         ["on_duty"] = "[E] - Go on duty",
-        ["on_duty"] = "[E] - Go off duty"
+        ["off_duty"] = "[E] - Go off duty"
     },
     menu = {
         ["taxi_menu_header"] = "Veículos de Taxi",

--- a/locales/sv.lua
+++ b/locales/sv.lua
@@ -21,7 +21,7 @@ local Translations = {
         ["blip_name"] = "Taxi",
         ["taxi_label_1"] = "Standard-bil",
         ["on_duty"] = "[E] - Go on duty",
-        ["on_duty"] = "[E] - Go off duty"
+        ["off_duty"] = "[E] - Go off duty"
     },
     menu = {
         ["taxi_menu_header"] = "Taxibilar",

--- a/locales/th.lua
+++ b/locales/th.lua
@@ -23,7 +23,7 @@ local Translations = {
         ["no_spawn_point"] = "หาสถานที่ไปเอารถแท็กซี่ไม่ได้",
         ["taxi_returned"] = "ที่จอดแท็กซี่",
         ["on_duty"] = "[E] - Go on duty",
-        ["on_duty"] = "[E] - Go off duty"
+        ["off_duty"] = "[E] - Go off duty"
     },
     menu = {
         ["taxi_menu_header"] = "รถแท็กซี่",

--- a/locales/tr.lua
+++ b/locales/tr.lua
@@ -21,7 +21,7 @@ local Translations = {
         ["blip_name"] = "Downtown Cab",
         ["taxi_label_1"] = "Standart Cab",
         ["on_duty"] = "[E] - Go on duty",
-        ["on_duty"] = "[E] - Go off duty"
+        ["off_duty"] = "[E] - Go off duty"
     },
     menu = {
         ["taxi_menu_header"] = "Taksi Araçları",


### PR DESCRIPTION
Implementation of the suggestion https://github.com/qbcore-framework/qb-taxijob/issues/80 . The info.on_duty duplicated which corresponded to off_duty has been changed to "off_duty". Now off duty's translates won't be nil.

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? No
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
